### PR TITLE
fix: add maven-wrapper.properties to repository

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip


### PR DESCRIPTION
Add Maven wrapper properties to versioned files so it can be used to run mvnw.cmd commands.

Closes #12