### PR TITLE
fix: update webhook endpoint

### DIFF
--- a/src/main/java/ContinuousIntegrationServer.java
+++ b/src/main/java/ContinuousIntegrationServer.java
@@ -8,7 +8,7 @@ import org.json.*;
 
 public class ContinuousIntegrationServer extends AbstractHandler {
 
-    private static final String WEBHOOK_ENDPOINT = "/"; // TODO change endpoint on GitHub
+    private static final String WEBHOOK_ENDPOINT = "/webhook";
 
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
 


### PR DESCRIPTION
Update endpoint that receives GitHub webhooks from "/" to the more robust "/webhook"

Closes #18